### PR TITLE
Add AppConfig for env-based settings

### DIFF
--- a/src/core/config.py
+++ b/src/core/config.py
@@ -1,14 +1,42 @@
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-class Settings(BaseSettings):
-    """Service configuration."""
+class AppConfig(BaseSettings):
+    """Application configuration loaded from environment variables."""
 
-    host: str = "0.0.0.0"
-    port: int = 8000
-    debug: bool = False
+    service_name: str = "generated-service"
+    service_version: str = "1.0.0"
+    service_port: int = 8000
+    service_host: str = "0.0.0.0"
 
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+    redis_url: str = "redis://localhost:6379"
+    redis_stream_name: str = "tasks:stream"
+    redis_consumer_group: str = "processors"
+    redis_consumer_name: str = "worker"
+
+    statsd_host: str = "localhost"
+    statsd_port: int = 8125
+    statsd_prefix: str = "microservice"
+
+    jaeger_endpoint: str = "http://localhost:14268/api/traces"
+    jaeger_service_name: str = "generated-service"
+
+    loki_endpoint: str = "http://localhost:3100/loki/api/v1/push"
+
+    uvloop_enabled: bool = True
+    worker_processes: str = "auto"
+    max_concurrent_tasks: int = 1000
+    task_timeout: int = 30
+    max_payload_size: int = 1048576
+
+    shutdown_timeout: int = 30
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+    )
 
 
-settings = Settings()
+def get_config() -> AppConfig:
+    """Return the application configuration instance."""
+    return AppConfig()

--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,7 @@ from starlette.responses import JSONResponse
 from starlette.routing import Route
 import uvicorn
 
-from core.config import settings
+from core.config import AppConfig
 from core.logging_config import configure_logging
 
 
@@ -17,7 +17,8 @@ def create_app() -> Starlette:
     return Starlette(routes=[Route("/health", healthcheck, methods=["GET"])])
 
 
+config = AppConfig()
 app = create_app()
 
 if __name__ == "__main__":
-    uvicorn.run("main:app", host=settings.host, port=settings.port)
+    uvicorn.run("main:app", host=config.service_host, port=config.service_port)


### PR DESCRIPTION
## Summary
- implement `AppConfig` with all environment variables from AGENTS.md
- expose helper `get_config`
- create config instance in `main.py`

## Testing
- `pytest -q`
- `nox -s ci-3.12 ci-3.13` *(fails: no noxfile found)*

------
https://chatgpt.com/codex/tasks/task_e_686e35e6eae48330a0bbc83acb524fff