### PR TITLE
Implement uvloop startup

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,12 @@
+"""Application entry point."""
+
+from multiprocessing import cpu_count
+
+import uvicorn
+import uvloop
 from starlette.applications import Starlette
 from starlette.responses import JSONResponse
 from starlette.routing import Route
-import uvicorn
 
 from core.config import AppConfig, configure_logging
 
@@ -19,5 +24,21 @@ config = AppConfig()
 configure_logging()
 app = create_app()
 
+
+def _get_workers(cfg: AppConfig) -> int:
+    """Return number of worker processes."""
+
+    return cpu_count() if cfg.worker_processes == "auto" else int(cfg.worker_processes)
+
+
 if __name__ == "__main__":
-    uvicorn.run("main:app", host=config.service_host, port=config.service_port)
+    loop_type = "uvloop" if config.uvloop_enabled else "asyncio"
+    if config.uvloop_enabled:
+        uvloop.install()
+    uvicorn.run(
+        "main:app",
+        host=config.service_host,
+        port=config.service_port,
+        loop=loop_type,
+        workers=_get_workers(config),
+    )


### PR DESCRIPTION
## Summary
- integrate uvloop-based Uvicorn config
- allow auto worker selection based on CPU count

## Testing
- `pytest -q`
- `nox -s ci-3.12 ci-3.13` *(fails: no noxfile)*

------
https://chatgpt.com/codex/tasks/task_e_686e41835660833083c6b9905882ac20