### PR TITLE
Implement HealthCheck endpoint

### DIFF
--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -6,14 +6,27 @@ from starlette.testclient import TestClient
 
 sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
 from core.config import configure_logging
-from main import app
+from main import app, config
+from unittest.mock import AsyncMock, patch
+from datetime import datetime
 
 
-def test_should_return_202_when_health_requested() -> None:
-    client = TestClient(app)
-    response = client.get("/health")
-    assert response.status_code == 202
-    assert response.json() == {"status": "ok"}
+def test_should_return_ok_when_redis_available() -> None:
+    redis_mock = AsyncMock()
+    redis_mock.__aenter__.return_value = redis_mock
+    redis_mock.__aexit__.return_value = False
+    redis_mock.ping = AsyncMock(return_value=True)
+
+    with patch("main.Redis.from_url", return_value=redis_mock):
+        client = TestClient(app)
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "healthy"
+    assert body["redis_connected"] is True
+    assert body["version"] == config.service_version
+    datetime.fromisoformat(body["timestamp"])
 
 
 def test_should_output_json_when_logging_configured(capsys) -> None:


### PR DESCRIPTION
## Summary
- provide `HealthResponse` model and `/health` route
- check Redis connection via async ping
- update tests for new health check logic

## Testing
- `pytest -q`
- `nox -s ci-3.12 ci-3.13` *(fails: noxfile missing)*

------
https://chatgpt.com/codex/tasks/task_e_686e4340b09c8330a067fde1a24df45e