### PR TITLE
Add async task processor

### DIFF
--- a/src/service/task_processor.py
+++ b/src/service/task_processor.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Awaitable, Callable
+
+from loguru import logger
+from redis.asyncio import Redis
+
+from core.config import AppConfig
+from tasks.models import TaskMessage
+
+
+AsyncHandler = Callable[[TaskMessage], Awaitable[None]]
+
+
+async def process_tasks(config: AppConfig, handler: AsyncHandler) -> None:
+    """Continuously read and process tasks from Redis Streams."""
+
+    stream = config.redis_stream_name
+    group = config.redis_consumer_group
+    consumer = config.redis_consumer_name
+
+    redis = Redis.from_url(config.redis_url)
+    async with redis:
+        try:
+            await redis.xgroup_create(stream, group, mkstream=True)
+        except Exception:
+            # Group might already exist
+            pass
+
+        logger.info(f"Connected to Redis stream {stream}")
+
+        while True:
+            try:
+                records = await redis.xreadgroup(
+                    group,
+                    consumer,
+                    streams={stream: ">"},
+                    count=1,
+                    block=1000,
+                )
+                if not records:
+                    continue
+
+                for _, messages in records:
+                    for message_id, data in messages:
+                        raw = data.get(b"task", b"{}").decode()
+                        try:
+                            task = TaskMessage.model_validate_json(raw)
+                        except Exception as exc:
+                            logger.error(f"Invalid task data: {exc}")
+                            await redis.xack(stream, group, message_id)
+                            await redis.xdel(stream, message_id)
+                            continue
+
+                        for attempt, delay in enumerate((0.1, 0.2, 0.4), start=1):
+                            try:
+                                await handler(task)
+                                await redis.xack(stream, group, message_id)
+                                await redis.xdel(stream, message_id)
+                                break
+                            except Exception as exc:
+                                logger.error(f"Task processing failed: {exc}")
+                                if attempt == 3:
+                                    await redis.xack(stream, group, message_id)
+                                    await redis.xdel(stream, message_id)
+                                else:
+                                    await asyncio.sleep(delay)
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.error(f"Processor error: {exc}")
+                await asyncio.sleep(1)

--- a/tests/unit/test_task_processor.py
+++ b/tests/unit/test_task_processor.py
@@ -1,0 +1,57 @@
+import asyncio
+import contextlib
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
+from core.config import AppConfig
+from service.task_processor import process_tasks
+from tasks.models import TaskPayload, TaskMessage, TraceContext
+
+
+@pytest.mark.asyncio
+async def test_should_process_task_asynchronously() -> None:
+    config = AppConfig()
+    message = TaskMessage(
+        task_id="1",
+        timestamp="2025-01-01T00:00:00Z",
+        payload=TaskPayload(data="foo", metadata={}),
+        trace_context=TraceContext(trace_id="t", span_id="s"),
+    )
+    redis_mock = AsyncMock()
+    redis_mock.__aenter__.return_value = redis_mock
+    redis_mock.__aexit__.return_value = False
+    redis_mock.xgroup_create = AsyncMock()
+    redis_mock.xack = AsyncMock()
+    redis_mock.xdel = AsyncMock()
+    redis_mock.xreadgroup = AsyncMock(
+        side_effect=[
+            [
+                (
+                    config.redis_stream_name.encode(),
+                    [(b"1-0", {b"task": message.model_dump_json().encode()})],
+                )
+            ],
+            asyncio.CancelledError(),
+        ]
+    )
+    handled = []
+
+    async def handler(msg: TaskMessage) -> None:
+        handled.append(msg.task_id)
+
+    with patch("service.task_processor.Redis.from_url", return_value=redis_mock):
+        task = asyncio.create_task(process_tasks(config, handler))
+        await asyncio.sleep(0)
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    assert handled == ["1"]
+    redis_mock.xack.assert_called_once_with(
+        config.redis_stream_name, config.redis_consumer_group, b"1-0"
+    )
+    redis_mock.xdel.assert_called_once_with(config.redis_stream_name, b"1-0")


### PR DESCRIPTION
## Summary
- implement `process_tasks` service
- start task processor on app startup
- log tasks from processor
- test async processing

## Testing
- `pytest -q`
- `nox -s ci-3.12 ci-3.13` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686e4825754c83308be845b5bc81182c